### PR TITLE
Prevent drag-n-drop to a diagram when locked #186

### DIFF
--- a/source/html/js/app/ui/dragdrop.js
+++ b/source/html/js/app/ui/dragdrop.js
@@ -2,12 +2,12 @@
        SPDX-License-Identifier: Apache-2.0 */
 
 define(["jquery", "lodash", "app/model", "app/channels", "app/ui/layout", "app/ui/diagrams", "app/ui/tile_view", "app/ui/confirmation", "app/ui/alert", "app/ui/channels_menu"],
-    function($, _, model, channels, layout, diagrams, tile_view, confirmation, alert, channels_menu) {
+    function ($, _, model, channels, layout, diagrams, tile_view, confirmation, alert, channels_menu) {
 
         var drag_id;
         var drag_type;
 
-        function drop_node_to_diagram() {
+        function drop_node_to_diagram(event) {
             var diagram = diagrams.shown();
             var node;
             var canvas;
@@ -34,9 +34,9 @@ define(["jquery", "lodash", "app/model", "app/channels", "app/ui/layout", "app/u
             var html;
             if (node) {
                 html = `Add ${node.header} to tile ${name}?`;
-                confirmation.show(html, function() {
+                confirmation.show(html, function () {
                     // confirm add node to tile
-                    channels.update_channel(name, [node.id]).then(function() {
+                    channels.update_channel(name, [node.id]).then(function () {
                         alert.show("Added to tile");
                         tile_view.redraw_tiles();
                     });
@@ -68,9 +68,9 @@ define(["jquery", "lodash", "app/model", "app/channels", "app/ui/layout", "app/u
             if (source_diagram) {
                 console.log("add diagram contents from " + source_diagram.name + " to tile " + name);
                 html = `Add contents from diagram ${source_diagram.name} to tile ${name}?`;
-                confirmation.show(html, function() {
+                confirmation.show(html, function () {
                     node_ids = source_diagram.nodes.getIds();
-                    channels.update_channel(name, node_ids).then(function() {
+                    channels.update_channel(name, node_ids).then(function () {
                         alert.show("Added to tile");
                         tile_view.redraw_tiles();
                     });
@@ -83,7 +83,7 @@ define(["jquery", "lodash", "app/model", "app/channels", "app/ui/layout", "app/u
             var target_diagram = diagrams.shown();
             if (target_diagram) {
                 console.log("add tile contents from " + tile_name + " to diagram " + target_diagram.name);
-                channels.retrieve_channel(tile_name).then(function(contents) {
+                channels.retrieve_channel(tile_name).then(function (contents) {
                     var channel_node_ids = _.map(contents, "id").sort();
                     // vis returns null for each id it can't find, therefore _.compact
                     var nodes = _.compact(model.nodes.get(channel_node_ids));
@@ -103,12 +103,12 @@ define(["jquery", "lodash", "app/model", "app/channels", "app/ui/layout", "app/u
             var html;
             if (source_tile_name !== target_tile_name) {
                 html = `Add contents from tile ${source_tile_name} to tile ${target_tile_name}?`;
-                confirmation.show(html, function() {
+                confirmation.show(html, function () {
                     var source_node_ids;
-                    channels.retrieve_channel(source_tile_name).then(function(source_contents) {
+                    channels.retrieve_channel(source_tile_name).then(function (source_contents) {
                         source_node_ids = _.map(source_contents, "id").sort();
                         return channels.update_channel(target_tile_name, source_node_ids);
-                    }).then(function() {
+                    }).then(function () {
                         alert.show("Added to tile");
                         tile_view.redraw_tiles();
                     });
@@ -121,7 +121,7 @@ define(["jquery", "lodash", "app/model", "app/channels", "app/ui/layout", "app/u
             var html;
             if (node) {
                 html = `Create a new tile with ${node.header}?`;
-                confirmation.show(html, function() {
+                confirmation.show(html, function () {
                     // confirm add node to tile
                     channels_menu.show_quick_new_tile([node.id]);
                 });
@@ -133,7 +133,7 @@ define(["jquery", "lodash", "app/model", "app/channels", "app/ui/layout", "app/u
             var html;
             if (diagram) {
                 html = `Create a new tile from diagram ${diagram.name} contents?`;
-                confirmation.show(html, function() {
+                confirmation.show(html, function () {
                     var node_ids = diagram.nodes.getIds();
                     // confirm add node to tile
                     channels_menu.show_quick_new_tile(node_ids);
@@ -144,58 +144,83 @@ define(["jquery", "lodash", "app/model", "app/channels", "app/ui/layout", "app/u
         function drop_tile_to_tile_canvas() {
             var source_tile_name = drag_id;
             var html = `Create a new tile from tile ${source_tile_name} contents?`;
-            confirmation.show(html, function() {
+            confirmation.show(html, function () {
                 var source_node_ids;
-                channels.retrieve_channel(source_tile_name).then(function(source_contents) {
+                channels.retrieve_channel(source_tile_name).then(function (source_contents) {
                     source_node_ids = _.map(source_contents, "id").sort();
                     channels_menu.show_quick_new_tile(source_node_ids);
                 });
             });
         }
 
-        $("body").on("dragstart", function(event) {
+        $("body").on("dragstart", function (event) {
             try {
                 if (event.target.attributes["data-node-id"]) {
                     console.log("dragging node");
                     drag_id = event.target.attributes["data-node-id"].value;
                     drag_type = "node";
                 } else
-                if (event.target.attributes["data-diagram-name"]) {
-                    console.log("dragging diagram");
-                    drag_id = event.target.attributes["data-diagram-name"].value;
-                    drag_type = "diagram";
-                } else
-                if (event.target.attributes["data-tile-name"]) {
-                    console.log("dragging tile");
-                    drag_id = event.target.attributes["data-tile-name"].value;
-                    drag_type = "tile";
-                } else {
-                    console.log("ignoring unknown draggable");
-                }
+                    if (event.target.attributes["data-diagram-name"]) {
+                        console.log("dragging diagram");
+                        drag_id = event.target.attributes["data-diagram-name"].value;
+                        drag_type = "diagram";
+                    } else
+                        if (event.target.attributes["data-tile-name"]) {
+                            console.log("dragging tile");
+                            drag_id = event.target.attributes["data-tile-name"].value;
+                            drag_type = "tile";
+                        } else {
+                            console.log("ignoring unknown draggable");
+                        }
             } catch (exception) {
                 console.log(exception);
             }
         });
 
-        $("#diagram-tab-content")[0].addEventListener("dragenter", function(event) {
+        $("#diagram-tab-content")[0].addEventListener("dragenter", async function (event) {
+            const shown = diagrams.shown();
+            if (shown) {
+                if (await shown.isLocked()) {
+                    event.dataTransfer.dropEffect = "none";
+                }
+                else {
+                    event.dataTransfer.dropEffect = "copy";
+                    event.preventDefault();
+                }
+            }
+            else {
+                event.dataTransfer.dropEffect = "copy";
+                event.preventDefault();
+            }
+        }, false);
+
+        $("#diagram-tab-content")[0].addEventListener("dragover", async function (event) {
+            const shown = diagrams.shown();
+            if (shown) {
+                if (await shown.isLocked()) {
+                    event.dataTransfer.dropEffect = "none";
+                }
+                else {
+                    event.dataTransfer.dropEffect = "copy";
+                    event.preventDefault();
+                }
+            }
+            else {
+                event.dataTransfer.dropEffect = "copy";
+                event.preventDefault();
+            }
+        }, false);
+
+        $("#diagram-tab-content")[0].addEventListener("dragend", function (event) {
             event.preventDefault();
         }, false);
 
-        $("#diagram-tab-content")[0].addEventListener("dragover", function(event) {
-            event.preventDefault();
-        }, false);
-
-        $("#diagram-tab-content")[0].addEventListener("dragend", function(event) {
-            event.preventDefault();
-        }, false);
-
-        $("#diagram-tab-content")[0].addEventListener("drop", function(event) {
+        $("#diagram-tab-content")[0].addEventListener("drop", function (event) {
             var tile;
-            console.log(event);
             event.preventDefault();
             if (drag_type === "node" && drag_id) {
                 if (diagrams.shown()) {
-                    drop_node_to_diagram();
+                    drop_node_to_diagram(event);
                 } else if (tile_view.shown()) {
                     tile = $(event.target).parents("div[data-channel-name]");
                     console.log(tile);
@@ -206,32 +231,32 @@ define(["jquery", "lodash", "app/model", "app/channels", "app/ui/layout", "app/u
                     }
                 }
             } else
-            if (drag_type === "diagram" && drag_id) {
-                if (diagrams.shown()) {
-                    drop_diagram_to_diagram();
-                } else if (tile_view.shown()) {
-                    tile = $(event.target).parents("div[data-channel-name]");
-                    console.log(tile);
-                    if (tile.length === 1) {
-                        drop_diagram_to_tile(tile);
-                    } else {
-                        drop_diagram_to_tile_canvas();
+                if (drag_type === "diagram" && drag_id) {
+                    if (diagrams.shown()) {
+                        drop_diagram_to_diagram();
+                    } else if (tile_view.shown()) {
+                        tile = $(event.target).parents("div[data-channel-name]");
+                        console.log(tile);
+                        if (tile.length === 1) {
+                            drop_diagram_to_tile(tile);
+                        } else {
+                            drop_diagram_to_tile_canvas();
+                        }
                     }
-                }
-            } else
-            if (drag_type === "tile" && drag_id) {
-                if (diagrams.shown()) {
-                    drop_tile_to_diagram();
-                } else if (tile_view.shown()) {
-                    tile = $(event.target).parents("div[data-channel-name]");
-                    console.log(tile);
-                    if (tile.length === 1) {
-                        drop_tile_to_tile(tile);
-                    } else {
-                        drop_tile_to_tile_canvas();
+                } else
+                    if (drag_type === "tile" && drag_id) {
+                        if (diagrams.shown()) {
+                            drop_tile_to_diagram();
+                        } else if (tile_view.shown()) {
+                            tile = $(event.target).parents("div[data-channel-name]");
+                            console.log(tile);
+                            if (tile.length === 1) {
+                                drop_tile_to_tile(tile);
+                            } else {
+                                drop_tile_to_tile_canvas();
+                            }
+                        }
                     }
-                }
-            }
         }, false);
 
     });


### PR DESCRIPTION
*Issue #, if available:* #186

*Description of changes:*
Evaluate diagram locked status before allowing it to be a drop target.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
