### PR TITLE
DynamoDB custom resource fix & regional host names for S3 origins

### DIFF
--- a/source/msam/db/lambda_function.py
+++ b/source/msam/db/lambda_function.py
@@ -57,12 +57,17 @@ def make_default_settings(settings_table):
 
     # upgrade never-cache-regions setting if needed
     try:
-        response = table.get_item(Key={
-            "id": "never-cache-regions"
-        })
-        never_cache_regions = response["Item"]["value"]
-        inventory_regions = list(set(never_cache_regions).symmetric_difference(set(all_regions))) + ['global']
-        print(f"updated inventory-regions are {json.dumps(inventory_regions)}")
+        response = table.get_item(Key={"id": "never-cache-regions"})
+        if "Item" in response:
+            never_cache_regions = response["Item"]["value"]
+            inventory_regions = list(
+                set(never_cache_regions).symmetric_difference(
+                    set(all_regions))) + ['global']
+            print(
+                f"updated inventory-regions are {json.dumps(inventory_regions)}"
+            )
+        else:
+            print("problem reading never-cache-regions setting")
     except ClientError:
         print("never-cache-regions setting does not exist")
 

--- a/source/web-cloudformation/msam-browser-app-release.template
+++ b/source/web-cloudformation/msam-browser-app-release.template
@@ -72,7 +72,11 @@
                                 "", [{
                                         "Ref": "MSAMBrowserAppBucket"
                                     },
-                                    ".s3.amazonaws.com"
+                                    ".s3.",
+                                    {
+                                        "Ref": "AWS::Region"
+                                    },
+                                    ".amazonaws.com"
                                 ]
                             ]
                         },
@@ -108,7 +112,11 @@
                                 "", [{
                                         "Ref": "MSAMBrowserAppLoggingBucket"
                                     },
-                                    ".s3.amazonaws.com"
+                                    ".s3.",
+                                    {
+                                        "Ref": "AWS::Region"
+                                    },
+                                    ".amazonaws.com"
                                 ]
                             ]
                         },


### PR DESCRIPTION
*Issue #, if available:* 
#264 
#180 

*Description of changes:*
Fix DynamoDB default settings custom resource for fresh install
Add region name to S3 origins to prevent DNS propagation delay

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
