### PR TITLE
UI fixes #323 #352

### DIFF
--- a/source/html/js/app/ui/diagram_statemachine_factory.js
+++ b/source/html/js/app/ui/diagram_statemachine_factory.js
@@ -21,7 +21,7 @@ export function create(diagram) {
                 "create-page-container": {
                     _onEnter: function () {
                         // create the html
-                        var tab = `<a class="nav-item nav-link" id="${my_diagram.tab_id}" title="Click or Drag to a Diagram or Tile" data-diagram-name="${my_diagram.name}" draggable="true" data-bs-toggle="tab" data-bs-target="#${my_diagram.diagram_id}" href="#${my_diagram.diagram_id}" role="tab" aria-controls="${my_diagram.diagram_id}" aria-selected="false">${my_diagram.name}<i id="${my_diagram.tab_icon_id}" class="material-icons pl-1 small">image_aspect_ratio</i></a>`;
+                        var tab = `<a class="nav-item nav-link" id="${my_diagram.tab_id}" title="Click or Drag to a Diagram or Tile" data-diagram-name="${my_diagram.name}" draggable="true" data-bs-toggle="tab" data-bs-target="#${my_diagram.diagram_id}" href="#${my_diagram.diagram_id}" role="tab" aria-controls="${my_diagram.diagram_id}" aria-selected="false">${my_diagram.name}<i id="${my_diagram.tab_icon_id}" class="material-icons ps-1 small">image_aspect_ratio</i></a>`;
                         var diagram_div = `<div id="${my_diagram.diagram_id}" class="tab-pane fade" role="tabpanel" aria-labelledby="${my_diagram.tab_id}" style="height: inherit; width: inherit;"></div>`;
                         // add to containers
                         // skip Tiles tab

--- a/source/html/js/app/ui/tile_view.js
+++ b/source/html/js/app/ui/tile_view.js
@@ -336,9 +336,11 @@ const redraw_tiles = async function () {
         const menu_id = channel_card_id + "_menu";
         const dropdown_id = channel_card_id + "_dropdown";
         const preferred_diagram_div = channel_card_id + "_preferred";
+        const abbrev_tile_header = (local_channel_name.length > 40) ? 
+                    `${local_channel_name.slice(0, 25)}...` : local_channel_name;
         const tile = `
                         <div draggable="true" class="card ${border_class} ms-4 mb-4 px-0" id="${channel_card_id}" data-alert-count="${alert_count}" data-alarm-count="${alarm_count}" data-channel-name="${channel_name}" data-tile-name="${channel_name}" data-resource-count="${channel_members.length}" data-missing-count="${missing_count}" style="border-width: 3px; width: ${tile_width_px}px; min-width: ${tile_width_px}px; max-width: ${tile_width_px}px; height: ${tile_height_px}px; min-height: ${tile_height_px}px; max-height: ${tile_height_px}px;">
-                            <div class="card-header" style="cursor: pointer;" title="Click to Select, Doubleclick to Edit" id="${header_id}">${local_channel_name}
+                            <div class="card-header" style="cursor: pointer;" title="Click to Select, Doubleclick to Edit" id="${header_id}">${abbrev_tile_header}
                             </div>
                             <div class="card-body text-info my-0 py-1">
                                 <h5 class="card-title my-0 py-0" id="${channel_card_id}_events">${alert_count} alert event${alert_count === 1 ? "" : "s"}</h5>


### PR DESCRIPTION
*Issue #, if available:* #323 #352

*Description of changes:* Adjusted spacing on right-side tile/diagram tab icon. Long tile names are shortened. Tile name stays one line long to look consistent with tiles with shorter names.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
